### PR TITLE
formのfilesをbase64へ変換

### DIFF
--- a/src/compornents/form.vue
+++ b/src/compornents/form.vue
@@ -101,8 +101,6 @@
     methods: {
       convert: function(target_id) {
         var input_file = document.getElementById(target_id);
-        // ------------------------------------------------------------
-        // 値が変化した時に実行されるイベント
 
         // ファイルが選択されたか
         if(!(input_file.value)) return;

--- a/src/compornents/form.vue
+++ b/src/compornents/form.vue
@@ -72,7 +72,7 @@
             <label for="thumb_img">サムネイル画像</label>
           </div>
           <div class="col s10">
-            <input type="file" id="thumb_img" name="thumb_img">
+            <input type="file" id="thumb_img" name="thumb_img" @change="convert('thumb_img')">
           </div>
         </div>
         <div class="row upload-row">
@@ -80,21 +80,65 @@
             <label for="comic_img">4コマ漫画</label>
           </div>
           <div class="col s10">
-            <input type="file" id="comic_img" name="comic_img">
+            <input type="file" id="comic_img" name="comic_img" @change="convert('comic_img')">
           </div>
         </div>
       </div>
       <div class="modal-footer">
         <div class="row">
           <div class="col s12">
-            <button type="submit" class="modal-action modal-close waves-effect waves-green btn-flat" value="">追加する</button>
-            <button type="submit" class="modal-action modal-close waves-effect waves-green btn-flat" value="">キャンセル</button>
+            <button type="button" class="modal-action modal-close waves-effect waves-green btn-flat">追加する</button>
+            <button type="button" class="modal-action modal-close waves-effect waves-green btn-flat">キャンセル</button>
           </div>
         </div>
       </div>
     </form>
   </div>
 </template>
+
+<script>
+  module.exports = {
+    methods: {
+      convert: function(target_id) {
+        var input_file = document.getElementById(target_id);
+        // ------------------------------------------------------------
+        // 値が変化した時に実行されるイベント
+
+        // ファイルが選択されたか
+        if(!(input_file.value)) return;
+
+        // FileReader クラスに対応しているか
+        if(!(window.FileReader)) return;
+
+        // ------------------------------------------------------------
+        // File オブジェクトを取得（HTML5 世代）
+        // ファイルリストを取得
+        var file_list = input_file.files;
+        if(!file_list) return;
+
+        // 0 番目の File オブジェクトを取得
+        var file = file_list[0];
+        if(!file) return;
+
+        // ------------------------------------------------------------
+        // FileReader オブジェクトを生成
+        var file_reader = new FileReader();
+
+        // ------------------------------------------------------------
+        // 読み込み成功時に実行されるイベント
+        file_reader.onload = function(e){
+
+          // 出力テスト
+          console.log(file_reader.result);
+        };
+
+        // ------------------------------------------------------------
+        // 読み込みを開始する（Data URI Scheme 文字列を得る）
+        file_reader.readAsDataURL(file);
+      }
+    }
+  }
+</script>
 
 <style scoped>
 .modal {

--- a/src/compornents/form.vue
+++ b/src/compornents/form.vue
@@ -64,7 +64,7 @@
             <label for="rec_source">ラジオ音源</label>
           </div>
           <div class="col s10">
-            <input type="file" id="rec_source" name="rec_source">
+            <input type="file" id="rec_source" name="rec_source" @change="convert('rec_source')">
           </div>
         </div>
         <div class="row upload-row">


### PR DESCRIPTION
closed #3 

# WHY
GASではdoGetでファイルを受け取れないのでbase64で変換したのち文字列で送信し、gas側でデコードしないと入れないから

# WHAT
## やったこと
- `<input type=file>`に`@change="convert( id )`を加え更新時に自動でbase64に変換するようにした。
- 画像だけでなくオーディオも変換できたので加えた

## やってないこと
特になし